### PR TITLE
Update z-index of images

### DIFF
--- a/src/app/carousel/carousel.component.sass
+++ b/src/app/carousel/carousel.component.sass
@@ -8,7 +8,6 @@
   width: 100% 
   height: 100%
   user-select: none 
-  z-index: 10000
   transform-origin: top left
   box-sizing: border-box
   .carousel-container


### PR DESCRIPTION
Commit for removing z-index from the host element. 
Host Z-index was applied to images in carousel, which made it too high, conflicting with z-index system in app