### PR TITLE
fixed-ssr-refresh-issue

### DIFF
--- a/projects/angular-responsive-carousel/src/lib/carousel.component.ts
+++ b/projects/angular-responsive-carousel/src/lib/carousel.component.ts
@@ -256,7 +256,7 @@ export class CarouselComponent implements OnDestroy {
     }
 
     ngOnDestroy() {
-        this.touches.destroy();
+        this.touches?.destroy();
         //this.carousel.destroy();
     }
 


### PR DESCRIPTION
hi there,

I faced an issue in my project with SSR build, once i refresh the page I get the error like below 
`TypeError: Cannot read property 'destroy' of undefined at CarouselComponent.ngOnDestroy (E:\2-3-upgrade\js-storefront\project\dist\project-server\main.js:5767:22) at executeOnDestroys (E:\2-3-upgrade\js-storefront\project\dist\project-server\main.js:184473:28) at cleanUpView (E:\2-3-upgrade\js-storefront\project\dist\project-server\main.js:184397:9) at destroyViewTree (E:\2-3-upgrade\js-storefront\project\dist\project-server\main.js:184223:21) at destroyLView (E:\2-3-upgrade\js-storefront\project\dist\project-server\main.js:184375:9) at RootViewRef.destroy (E:\2-3-upgrade\js-storefront\project\dist\project-server\main.js:184989:9) at E:\2-3-upgrade\js-storefront\project\dist\project-server\main.js:203733:52 at Array.forEach (<anonymous>) at ApplicationRef.ngOnDestroy (E:\2-3-upgrade\js-storefront\project\dist\project-server\main.js:203733:29) at E:\2-3-upgrade\js-storefront\project\dist\project-server\main.js:186353:55`

so I just added a safe operator to avoid this error.


please merge this PR asap. I got this error in my production.


