### PR TITLE
Add dotsPerPage option

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ To use lazy loading, pass the carousel an array of images, as shown in the examp
 | autoplayInterval | number | 5000 | The interval between scrolling the carousel. Used together with autoplay. |
 | pauseOnHover | boolean | true | Stops autoplay if the cursor is over the carousel area. |
 | dots | boolean | false | Carousel progress bar. |
+| dotsPerPage | boolean | false | If cellsToShow and cellsToScroll are larger than 1, if dotsPerPage is true it will only show 1 dot per page of cells. So with 9 images and cellsToShow and Scrollset ot 3 it will show only 3 dots |
 | margin | number | 10 | Cell spacing. |
 | minSwipeDistance | number | 10 | Minimum distance for swipe. |
 | transitionDuration | number | 300 | Animation duration. |

--- a/projects/angular-responsive-carousel/src/lib/carousel.component.ts
+++ b/projects/angular-responsive-carousel/src/lib/carousel.component.ts
@@ -94,6 +94,9 @@ export class CarouselComponent implements OnDestroy {
     }
 
     get activeDotIndex() {
+        if (this.dotsPerPage) {
+           return Math.ceil(this.slideCounter / this.cellsToScroll);
+        }
         return this.slideCounter % this.cellLength;
     }
 
@@ -116,6 +119,7 @@ export class CarouselComponent implements OnDestroy {
     @Input() autoplayInterval: number = 5000;
     @Input() pauseOnHover: boolean = true;
     @Input() dots: boolean = false;
+    @Input() dotsPerPage: boolean = false;
     @Input() borderRadius!: number;
     @Input() margin: number = 10;
     @Input() objectFit: 'contain' | 'cover' | 'none' = 'cover';
@@ -237,7 +241,7 @@ export class CarouselComponent implements OnDestroy {
     ngAfterViewInit() {
         this.initCarousel();
         this.cellLength = this.getCellLength();
-        this.dotsArr = Array(this.cellLength).fill(1);
+        this.dotsArr = this.dotsPerPage ? Array(Math.ceil(this.cellLength/this.cellsToScroll)).fill(1): Array(this.cellLength).fill(1);
         this.ref.detectChanges();
         this.carousel.lineUpCells();
         this.savedCarouselWidth = this.carouselWidth;

--- a/projects/angular-responsive-carousel/src/lib/carousel.component.ts
+++ b/projects/angular-responsive-carousel/src/lib/carousel.component.ts
@@ -95,7 +95,7 @@ export class CarouselComponent implements OnDestroy {
 
     get activeDotIndex() {
         if (this.dotsPerPage) {
-           return Math.ceil(this.slideCounter / this.cellsToScroll);
+           return Math.ceil(this.slideCounter / this.cellsToScroll) % this.dotsArr.length;
         }
         return this.slideCounter % this.cellLength;
     }

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -156,6 +156,19 @@
 			</carousel>
 		</div>
 
+		<!-- cellsToShow, cellsToScroll, dotsPerPage -->
+		<div class="demo">
+			<h3>cellsToShow = 3, cellsToScroll = 3, dotsPerPage = true</h3>
+			<carousel
+				[images]="images"
+				[height]="150"
+				[cellsToShow]="3"
+				[cellsToScroll]="3"
+            [dots]="true"
+            [dotsPerPage]="true">
+			</carousel>
+		</div>
+      
 		<!-- objectFit -->
 		<div class="demo">
 			<h3>objectFit = contain</h3>


### PR DESCRIPTION
This adds an option to not show a dot per image, but show a dot per page of images.
If `cellsToShow = 3, cellsToScroll = 3, dotsPerPage = true` and the number of images is 10 then there are only 4 dots shown, for each set of 3 1 dot (and one extra for the last image)